### PR TITLE
Transfer to ethersphere organization

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,27 @@
-MIT License
+Copyright (c) 2022 The Swarm Authors. All rights reserved.
 
-Copyright (c) 2022 Philippe Schommers
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+- Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+- Neither the name of Swarm nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/package.json
+++ b/package.json
@@ -15,8 +15,11 @@
     "actions",
     "typescript"
   ],
-  "author": "Philippe Schommers <philippe@schommers.be>",
-  "license": "MIT",
+  "homepage": "https://github.com/ethersphere/swarm-actions",
+  "bugs": {
+    "url": "https://github.com/ethersphere/swarm-actions/issues/"
+  },
+  "license": "BSD-3-Clause",
   "dependencies": {
     "@actions/core": "1.6.0",
     "@ethersphere/bee-js": "3.3.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "GitHub Actions for Swarm",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/filoozom/swarm-actions.git"
+    "url": "git+https://github.com/ethersphere/swarm-actions.git"
   },
   "keywords": [
     "ethersphere",

--- a/pr-preview/README.md
+++ b/pr-preview/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: filoozom/swarm-actions/pr-preview@v1
+      - uses: ethersphere/swarm-actions/pr-preview@v1
         with:
           bee-url: https://api.gateway.ethswarm.org
           postage-batch-id: '0000000000000000000000000000000000000000000000000000000000000000'

--- a/pr-preview/action.yaml
+++ b/pr-preview/action.yaml
@@ -48,7 +48,7 @@ runs:
   steps:
     - id: upload
       name: Upload to Swarm
-      uses: filoozom/swarm-actions/upload-dir@v0
+      uses: ethersphere/swarm-actions/upload-dir@v0
       with:
         bee-url: ${{ inputs.bee-url }}
         postage-batch-id: ${{ inputs.postage-batch-id }}
@@ -57,7 +57,7 @@ runs:
 
     - id: cid
       name: Convert reference to CID
-      uses: filoozom/swarm-actions/reference-to-cid@v0
+      uses: ethersphere/swarm-actions/reference-to-cid@v0
       with:
         reference: ${{ steps.upload.outputs.reference }}
 

--- a/reference-to-cid/README.md
+++ b/reference-to-cid/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: filoozom/swarm-actions/reference-to-cid@v1
+      - uses: ethersphere/swarm-actions/reference-to-cid@v1
         with:
           reference: '0000000000000000000000000000000000000000000000000000000000000000'
 ```

--- a/upload-dir/README.md
+++ b/upload-dir/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: filoozom/swarm-actions/upload-dir@v1
+      - uses: ethersphere/swarm-actions/upload-dir@v1
         with:
           bee-url: https://api.gateway.ethswarm.org
           postage-batch-id: '0000000000000000000000000000000000000000000000000000000000000000'

--- a/write-feed/README.md
+++ b/write-feed/README.md
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: filoozom/swarm-actions/write-feed@v1
+      - uses: ethersphere/swarm-actions/write-feed@v1
         with:
           bee-url: http://localhost:1633
           postage-batch-id: '0000000000000000000000000000000000000000000000000000000000000000'


### PR DESCRIPTION
Basically replace all references to `filoozom/swarm-actions` to `ethersphere/swarm-actions`.

I guess there's the licensing stuff to figure out too.