### PR TITLE
Use secret to commit release changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_GHA_PAT }}
+
       - uses: actions/setup-node@v3
         with:
           node-version: '16'


### PR DESCRIPTION
Right now there's an issue with the release workflow because a commit is pushed with changes to the version in `package.json` and `package-lock.json`. However, the standard token does not have permission to push changes to `main`. This PR uses a token that should be allowed to push commits.

See https://github.com/EndBug/add-and-commit#about-tokens and https://github.com/actions/checkout#usage.